### PR TITLE
removed deprecated code

### DIFF
--- a/nested.rb
+++ b/nested.rb
@@ -58,7 +58,7 @@ def dennis_ritchies_language
 end
 
 def adding_matz
-# add the following information to the top level of the programmer hash
+# add the following information to the top level of programmer_hash
 # :yukihiro_matsumoto => {
 #   :known_for => "Ruby",
 #    :languages => ["LISP, C"]
@@ -99,7 +99,7 @@ def changing_alan
           :languages => ["C"]
         }
      }
-     #change what Alan Kay is :known_for the value of the alans_new_info variable. 
+     #change what Alan Kay is :known_for to the value of the alans_new_info variable. 
      alans_new_info = "GUI"
      
      
@@ -122,18 +122,4 @@ def adding_to_dennis
         }
      }
 
-     
 end
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 


### PR DESCRIPTION
```bash
Deprecation Warnings:

RSpec::Core::Configuration#treat_symbols_as_metadata_keys_with_true_values= is deprecated, it is now set to true as default and setting it to false has no effect.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total
```