### PR TITLE
fix syntactic typo in the adding_matz instructions

### DIFF
--- a/nested.rb
+++ b/nested.rb
@@ -61,7 +61,7 @@ def adding_matz
 # add the following information to the top level of programmer_hash
 # :yukihiro_matsumoto => {
 #   :known_for => "Ruby",
-#    :languages => ["LISP, C"]
+#    :languages => ["LISP", "C"]
 # }
 
 	programmer_hash = 


### PR DESCRIPTION
Fixes https://github.com/learn-co-curriculum/simple-nesting/issues/18

Changed `:languages => ["LISP, C"]` to `:languages => ["LISP", "C"]`