### PR TITLE
fix syntactic typo in the adding_matz instructions

### DIFF
--- a/nested.rb
+++ b/nested.rb
@@ -64,7 +64,7 @@ def adding_matz
 # add the following information to the top level of the programmer hash
 # :yukihiro_matsumoto => {
 #   :known_for => "Ruby",
-#    :languages => ["LISP, C"]
+#    :languages => ["LISP", "C"]
 # }
 
   programmer_hash = 


### PR DESCRIPTION
Cherry picks fixes from 6be2980263f35527314f9791f61732894b8ca2b8 on master

for issue #20 

Changed `:languages => ["LISP, C"]` to `:languages => ["LISP", "C"]`